### PR TITLE
Fixing import for pip >= 10

### DIFF
--- a/admin_auto_tests/test_model.py
+++ b/admin_auto_tests/test_model.py
@@ -2,7 +2,11 @@ from unittest import SkipTest
 
 from autofixture import AutoFixture
 from django.contrib.auth import get_user_model
-from django.core.urlresolvers import reverse
+try:
+    from django.core.urlresolvers import reverse
+except:
+    from django.urls import reverse
+
 from django.forms import model_to_dict
 from django.test import TestCase
 

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,16 @@
 """Package description
 """
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
 from distutils.util import convert_path
 from fnmatch import fnmatchcase
 import os
 import sys
 import uuid
+
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 ###############################
 #  Configuración del paquete  #


### PR DESCRIPTION
It looks like pip >= 10 changed the pip.req import, I found this stack overflow page [1] describing a fix that appears to work

1. https://stackoverflow.com/questions/25192794/no-module-named-pip-req?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa